### PR TITLE
Push cli success and failure messaging to root index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,5 @@ matrix:
     - os: linux
       node_js: "7"
     - os: osx
-      node_js: "4"
-    - os: osx
       node_js: "6"
-    - os: osx
-      node_js: "7"
   fast_finish: true

--- a/index.js
+++ b/index.js
@@ -1,4 +1,16 @@
 require("babel-register");
+var logger = require('./lib/logger').default;
+
+var fatalError = function(err) {
+  logger.error(err);
+  process.exit(1);
+};
 
 var argv = require('yargs').argv;
-require('./lib').default(argv.webpack, argv.dependency);
+require('./lib').default(argv.webpack, argv.dependency, function(err) {
+  if (err) {
+    fatalError(err);
+  } else {
+    logger.success('All examples passed');
+  }
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,47 +6,38 @@ import generateInstallObjectFor from './generate-install-object';
 import installWebpackAndDependency from './install-webpack-and-dependency';
 import getDependencyExamples from './get-dependency-examples';
 import runDependencyWithWebpack from './run-dependency-with-webpack';
-import { fatalError } from './utils';
 
-export default function(webpackVersion, dependencyVersion) {
+export default function(webpackVersion, dependencyVersion, callback) {
   const runDependencyWithWebpackPromise = Promise.promisify(runDependencyWithWebpack);
-
-  const dependencyExampleFailure = function(err) {
-    fatalError(err);
-  };
-
-  const dependencyExamplesSuccess = function() {
-    logger.success('All examples passed');
-  };
 
   const webpackSetup = generateInstallObjectFor.webpack(webpackVersion);
   if (_.isNull(webpackSetup) || webpackSetup.name !== 'webpack') {
-    fatalError('Webpack version is not valid', webpackVersion);
+    callback(['Webpack version is not valid', webpackVersion]);
     return;
   }
 
   const dependencySetup = generateInstallObjectFor.dependency(dependencyVersion);
   if (_.isNull(dependencySetup)) {
-    fatalError('Dependency details provided are not valid', dependencyVersion);
+    callback(['Dependency details provided are not valid', dependencyVersion]);
     return;
   }
 
   logger.info(`Installing ${chalk.bold(webpackSetup)} and ${chalk.bold(dependencySetup)} ...`);
   installWebpackAndDependency(webpackSetup, dependencySetup, function(err) {
     if (err) {
-      fatalError(err);
+      callback(err);
       return;
     }
 
     logger.info(`Retrieving ${chalk.bold(dependencySetup.name)} examples ...`);
     getDependencyExamples(webpackSetup, dependencySetup, function(err, dependencyExamples) {
       if (err) {
-        fatalError(err);
+        callback(err);
         return;
       }
 
       if (_.isEmpty(dependencyExamples)) {
-        fatalError('Unable to get any dependency examples');
+        callback('Unable to get any dependency examples');
         return;
       }
 
@@ -58,8 +49,12 @@ export default function(webpackVersion, dependencyVersion) {
 
         return runDependencyWithWebpackPromise(dependencyExample.config);
       })
-      .then(dependencyExamplesSuccess)
-      .catch(dependencyExampleFailure);
+      .then(function() {
+        callback();
+      })
+      .catch(function(err) {
+        callback(err);
+      });
     });
   });
 }

--- a/lib/test/index.spec.js
+++ b/lib/test/index.spec.js
@@ -26,21 +26,16 @@ describe('Webpack Canary', function() {
         config: { entry: 'my-third-example' }
       }
     ];
-    env.fatalErrorMock = sinon.mock();
+    env.callbackMock = sinon.mock();
     env.installMock = sinon.mock();
     env.dependencyExampleMock = sinon.mock();
     env.runDependencyStub = function(config, callback) {
       env.dependencyRunError ? callback(new Error()) : callback();
     };
     sinon.spy(env, 'runDependencyStub');
-    env.loggerSuccessMock = sinon.mock();
     env.webpackCanary = proxyquireStrict('../', {
-      './utils': {
-        fatalError: env.fatalErrorMock
-      },
       './logger': {
         info: _.noop,
-        success: env.loggerSuccessMock
       },
       './install-webpack-and-dependency': env.installMock,
       './get-dependency-examples': env.dependencyExampleMock,
@@ -52,23 +47,23 @@ describe('Webpack Canary', function() {
     describe('and webpack version is not valid', function() {
       describe('version is missing', function() {
         beforeEach(function() {
-          env.webpackCanary();
+          env.webpackCanary(undefined, undefined, env.callbackMock);
         });
 
-        it('triggers a fatal error', function() {
-          expect(env.fatalErrorMock).to.have.been.calledOnce;
-          expect(env.fatalErrorMock).to.have.been.calledWith('Webpack version is not valid', undefined);
+        it('passes error in callback', function() {
+          expect(env.callbackMock).to.have.been.calledOnce;
+          expect(env.callbackMock).to.have.been.calledWith(['Webpack version is not valid', undefined]);
         });
       });
 
       describe('version is not for webpack', function() {
         beforeEach(function() {
-          env.webpackCanary('underscore@1.2.3');
+          env.webpackCanary('underscore@1.2.3', undefined, env.callbackMock);
         });
 
-        it('triggers a fatal error', function() {
-          expect(env.fatalErrorMock).to.have.been.calledOnce;
-          expect(env.fatalErrorMock).to.have.been.calledWith('Webpack version is not valid', 'underscore@1.2.3');
+        it('passes error in callback', function() {
+          expect(env.callbackMock).to.have.been.calledOnce;
+          expect(env.callbackMock).to.have.been.calledWith(['Webpack version is not valid', 'underscore@1.2.3']);
         });
       });
     });
@@ -80,23 +75,23 @@ describe('Webpack Canary', function() {
 
       describe('version is missing', function() {
         beforeEach(function() {
-          env.webpackCanary(env.webpackVersion);
+          env.webpackCanary(env.webpackVersion, undefined, env.callbackMock);
         });
 
-        it('triggers a fatal error', function() {
-          expect(env.fatalErrorMock).to.have.been.calledOnce;
-          expect(env.fatalErrorMock).to.have.been.calledWith('Dependency details provided are not valid', undefined);
+        it('passes error in callback', function() {
+          expect(env.callbackMock).to.have.been.calledOnce;
+          expect(env.callbackMock).to.have.been.calledWith(['Dependency details provided are not valid', undefined]);
         });
       });
     });
 
     describe('and both webpack and dependency versions are valid', function() {
       beforeEach(function() {
-        env.webpackCanary('1.2.3', 'raw-loader');
+        env.webpackCanary('1.2.3', 'raw-loader', env.callbackMock);
       });
 
       it('installs webpack and dependency', function() {
-        expect(env.fatalErrorMock).not.to.have.been.called;
+        expect(env.callbackMock).not.to.have.been.called;
         expect(env.installMock).to.have.been.calledOnce;
       });
     });
@@ -104,7 +99,7 @@ describe('Webpack Canary', function() {
 
   describe('Once install handler has completed', function() {
     beforeEach(function() {
-      env.webpackCanary('1.2.3', 'raw-loader');
+      env.webpackCanary('1.2.3', 'raw-loader', env.callbackMock);
       env.installCallback = env.installMock.firstCall.args[2];
     });
 
@@ -113,9 +108,9 @@ describe('Webpack Canary', function() {
         env.installCallback(new Error('test'));
       });
 
-      it('triggers a fatal error', function() {
-        expect(env.fatalErrorMock).to.have.been.calledOnce;
-        expect(env.fatalErrorMock).to.have.been.calledWith(new Error());
+      it('passes error in callback', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith(new Error());
       });
     });
 
@@ -125,7 +120,7 @@ describe('Webpack Canary', function() {
       });
 
       it('gets dependency examples', function() {
-        expect(env.fatalErrorMock).not.to.have.been.called;
+        expect(env.callbackMock).not.to.have.been.called;
         expect(env.dependencyExampleMock).to.have.been.calledOnce;
       });
     });
@@ -133,7 +128,7 @@ describe('Webpack Canary', function() {
 
   describe('Once examples have been retrieved', function() {
     beforeEach(function() {
-      env.webpackCanary('1.2.3', 'raw-loader');
+      env.webpackCanary('1.2.3', 'raw-loader', env.callbackMock);
       env.installCallback = env.installMock.firstCall.args[2];
       env.installCallback();
       env.dependencyExampleCallback = env.dependencyExampleMock.firstCall.args[2];
@@ -144,9 +139,9 @@ describe('Webpack Canary', function() {
         env.dependencyExampleCallback(new Error('test'));
       });
 
-      it('triggers a fatal error', function() {
-        expect(env.fatalErrorMock).to.have.been.calledOnce;
-        expect(env.fatalErrorMock).to.have.been.calledWith(new Error());
+      it('passes error in callback', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith(new Error());
       });
     });
 
@@ -155,9 +150,9 @@ describe('Webpack Canary', function() {
         env.dependencyExampleCallback(null, []);
       });
 
-      it('triggers a fatal error', function() {
-        expect(env.fatalErrorMock).to.have.been.calledOnce;
-        expect(env.fatalErrorMock).to.have.been.calledWith('Unable to get any dependency examples');
+      it('passes error in callback', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith('Unable to get any dependency examples');
       });
     });
 
@@ -173,10 +168,9 @@ describe('Webpack Canary', function() {
           expect(env.runDependencyStub).to.have.been.calledOnce;
         });
 
-        it('displays failure message', function() {
-          expect(env.fatalErrorMock).to.have.been.calledOnce;
-          expect(env.fatalErrorMock.firstCall.args[0]).to.be.an('object');
-          expect(env.loggerSuccessMock).not.to.have.been.called;
+        it('passes error in callback', function() {
+          expect(env.callbackMock).to.have.been.calledOnce;
+          expect(env.callbackMock.firstCall.args[0]).to.be.an('object');
         });
       });
 
@@ -191,9 +185,9 @@ describe('Webpack Canary', function() {
           expect(env.runDependencyStub).to.have.been.calledThrice;
         });
 
-        it('displays success message', function() {
-          expect(env.fatalErrorMock).not.to.have.been.called;
-          expect(env.loggerSuccessMock).to.have.been.calledOnce;
+        it('calls callback', function() {
+          expect(env.callbackMock).to.have.been.called;
+          expect(env.callbackMock).to.have.been.calledWithExactly();
         });
       });
     });

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,6 +1,0 @@
-import logger from '../logger';
-
-export const fatalError = function(...args) {
-  logger.error(...args);
-  process.exit(1);
-}


### PR DESCRIPTION
Update main file to use callback instead of calling process. This better separates the cli interface from the programatic interface.
Also reduce osx builds on travis as they are slow to spin up, keeping only latest stable node version test environment.