### PR TITLE
Output summary after squawk run with correct exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,11 @@ A dependency must include an `examples` directory which contains an example setu
  - [x] Tests
  - [x] Flag to control log level verbosity
  - [x] Programatic interface (split CLI flags from app)
- - [x] Script to run for multiple dependencies / versions with summary
+ - [x] Script to run for multiple dependencies
  - [x] Linting
+ - [x] Show summary successes / failure after running squawk
+ - [ ] Update summary to use progress bar and collapse table if all success
+ - [ ] Change logLevel to loglevel
+ - [ ] Update readme
+ - [ ] Split webpack 1 configs and 2 configs in examples
+ - [ ] Investigate why failing on webpack 1 causes failure in webpack 2 (cache?)

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 const outputWithColor = function(originalArguments, color) {
   const args = _.flatten(originalArguments);
   const value = chalk.bold[color](args[0]) + '\n' + _.map(_.rest(args), (value) => chalk[color](value)).join('\n');
-  console.log(value);
+  console.log(value.trim());
 };
 
 const orderedLogLevels = [
@@ -27,13 +27,13 @@ export default function(currentLogLevel = {}) {
     debug() {
       if (logLevelSeverity > logLevel.debug) return;
       const args = _.flatten(arguments);
-      console.log('[DEBUG]', args.join('\n'));
+      console.log('[DEBUG]', args.join('\n').trim());
     },
 
     info() {
       if (logLevelSeverity > logLevel.info) return;
       const args = _.flatten(arguments);
-      console.log(args.join('\n'));
+      console.log(args.join('\n').trim());
     },
 
     success() {

--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -1,5 +1,4 @@
 export default function(config, callback) {
-  // These dependencies are installed during runtime and cannot be imported
   const webpack = require('webpack');
   const compiler = webpack(config);
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-register": "^6.18.0",
     "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
+    "cli-table": "^0.3.1",
     "glob": "^7.1.1",
     "semver": "^5.3.0",
     "underscore": "^1.8.3",

--- a/squawk/index.js
+++ b/squawk/index.js
@@ -1,6 +1,7 @@
 import Promise from 'bluebird';
 import _ from 'underscore';
 import chalk from 'chalk';
+import Table from 'cli-table';
 import getLogger from '../lib/logger';
 import webpackVersions from './webpack-versions';
 import dependencyVersions from './dependency-versions';
@@ -19,20 +20,86 @@ const createRunList = function() {
     });
   });
   return _.flatten(nestedRunList);
+};
+
+const updateResults = function({ webpack, dependency }, results, update) {
+  results[webpack] = results[webpack] || {};
+  results[webpack][dependency] = _.extend({
+    webpack,
+    dependency
+  }, update);
+  return results;
+};
+
+const updateResultsForSuccess = function(versions, results) {
+  return updateResults(versions, results, {
+    success: true
+  });
+};
+
+const updateResultsForFailure = function(versions, err, results) {
+  return updateResults(versions, results, {
+    error: err,
+    success: false
+  });
 }
+
+const convertErrorToString = function(err) {
+  if (_.isArray(err)) {
+    return _.flatten(err).join('\n');
+  }
+  return err;
+};
+
+const completeTask = function(results) {
+  const resultsList = _.flatten(_.map(_.values(results), (dependencies) => _.values(dependencies)));
+
+  if (_.some(resultsList, (result) => !result.success)) {
+    logger.error('Compilation failures. Please review results above.');
+    process.exit(1);
+  }
+
+  logger.success('Compilations complete. No issues detected.');
+  process.exit();
+};
+
+const generateSummary = function(results) {
+  _.each(results, function(webpackResults, webpackVersion) {
+    console.log(chalk.bold.underline(`Webpack ${webpackVersion}`));
+
+    const table = new Table({
+      head: ['Status', 'Name', 'Error'],
+      style: { head: ['bold'] }
+    });
+
+    _.each(webpackResults, function({ success, error }, dependencyVersion) {
+      const dependencyStatus = success ? chalk.green('Passed') : chalk.red('Failed');
+      const dependencyError = error ? chalk.red(convertErrorToString(error)) : '';
+      table.push(
+        [dependencyStatus, dependencyVersion, dependencyError]
+      );
+    });
+
+    console.log(`${table}\n`);
+  });
+
+  completeTask(results);
+};
 
 export default function() {
   const runList = createRunList();
+  let results = {};
+
   Promise.each(runList, function({ webpack, dependency }) {
     logger.info(`Running ${chalk.bold(webpack)} and ${chalk.bold(dependency)} ...`);
-    return squawk(webpack, dependency, options).catch(function(err) {
-      logger.error(err);
+    return squawk(webpack, dependency, options).then(function() {
+      results = updateResultsForSuccess({ webpack, dependency }, results);
+    }).catch(function(err) {
+      results = updateResultsForFailure({ webpack, dependency }, err, results);
     });
-  })
-  .then(function() {
-    logger.info('Complete');
-  })
-  .catch(function(err) {
+  }).then(function() {
+    generateSummary(results);
+  }).catch(function(err) {
     logger.error('Error ocurred running all combinations', err);
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,6 +675,12 @@ cli-cursor@^1.0.1:
   dependencies:
     restore-cursor "^1.0.1"
 
+cli-table@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
+  dependencies:
+    colors "1.0.3"
+
 cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
@@ -694,6 +700,10 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+colors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
 commander@2.9.0:
   version "2.9.0"


### PR DESCRIPTION
Outputs a summary table for each version of webpack which was run. Also sets the exit code if errors were detected. Currently failing due to missing examples in listed dependencies.