### PR TITLE
Run webpack via CLI to sidestep require issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
     - os: linux
       node_js: "7"
       env: SQUAWK=false
-    - os: osx
-      node_js: "6"
-      env: SQUAWK=false
     - os: linux
       node_js: "7"
       env: SQUAWK=true

--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ A dependency must include an `examples` directory which contains an example setu
  - [ ] Change logLevel to loglevel
  - [ ] Update readme
  - [ ] Split webpack 1 configs and 2 configs in examples
- - [ ] Investigate why failing on webpack 1 causes failure in webpack 2 (cache?)
+ - [x] Investigate why failing on webpack 1 causes failure in webpack 2 (cache?)
+ - [ ] Add ability to run more than just loaders / plugins

--- a/lib/get-dependency-examples/index.js
+++ b/lib/get-dependency-examples/index.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import _ from 'underscore';
 import glob from 'glob';
-import retrieveExampleConfig from './retrieve-example-config';
 
 export default function(webpackSetup, dependencySetup, callback) {
   const webpackConfigFilename = 'webpack.config.js';
@@ -23,7 +22,7 @@ export default function(webpackSetup, dependencySetup, callback) {
 
       return {
         name: (examplesName === '.') ? undefined : examplesName,
-        config: retrieveExampleConfig(path.join(dependencyExamplesPath, webpackConfigFilePath))
+        config: path.join('node_modules', dependencyExamplesPath, webpackConfigFilePath)
       }
     });
 

--- a/lib/get-dependency-examples/retrieve-example-config.js
+++ b/lib/get-dependency-examples/retrieve-example-config.js
@@ -1,3 +1,0 @@
-export default function(path) {
-  return require(path)
-}

--- a/lib/get-dependency-examples/test/index.spec.js
+++ b/lib/get-dependency-examples/test/index.spec.js
@@ -13,14 +13,9 @@ describe('getDependencyExamples', function() {
   beforeEach(function() {
     env = {};
     env.globMock = sinon.mock();
-    env.retrieveStub = sinon.stub();
-    env.retrieveStub.onFirstCall().returns({ entry: 'my-first-example' });
-    env.retrieveStub.onSecondCall().returns({ entry: 'my-second-example' });
-    env.retrieveStub.onThirdCall().returns({ entry: 'my-third-example' });
     env.callbackMock = sinon.mock();
     env.getDependencyExamples = proxyquireStrict('../', {
-      'glob': env.globMock,
-      './retrieve-example-config': env.retrieveStub
+      'glob': env.globMock
     }).default;
     env.getDependencyExamples(new InstallObject('webpack@2.3.4'), new InstallObject('raw-loader@1.2.3'), env.callbackMock);
     env.globCallback = env.globMock.firstCall.args[2];
@@ -41,10 +36,6 @@ describe('getDependencyExamples', function() {
       env.globCallback(new Error('test'));
     });
 
-    it('does not retrieve example config', function() {
-      expect(env.retrieveStub).not.to.have.been.called;
-    });
-
     it('calls the callback with error', function() {
       expect(env.callbackMock).to.have.been.calledOnce;
       expect(env.callbackMock).to.have.been.calledWith(new Error());
@@ -56,17 +47,12 @@ describe('getDependencyExamples', function() {
       env.globCallback(null, ['webpack.config.js']);
     });
 
-    it('retrieves the example config', function() {
-      expect(env.retrieveStub).to.have.been.calledOnce;
-      expect(env.retrieveStub).to.have.been.calledWith('raw-loader/examples/webpack.config.js');
-    });
-
     it('calls the callback with array of one config', function() {
       expect(env.callbackMock).to.have.been.calledOnce;
       expect(env.callbackMock.firstCall.args[1]).to.deep.equal([
         {
           name: undefined,
-          config: { entry: 'my-first-example' }
+          config: 'node_modules/raw-loader/examples/webpack.config.js'
         }
       ]);
     });
@@ -82,27 +68,20 @@ describe('getDependencyExamples', function() {
       env.globCallback(null, examples);
     });
 
-    it('retrieves the example config', function() {
-      expect(env.retrieveStub).to.have.been.calledThrice;
-      expect(env.retrieveStub).to.have.been.calledWith('raw-loader/examples/example-1/webpack.config.js');
-      expect(env.retrieveStub).to.have.been.calledWith('raw-loader/examples/example-2/webpack.config.js');
-      expect(env.retrieveStub).to.have.been.calledWith('raw-loader/examples/example-3/webpack.config.js');
-    });
-
     it('calls the callback with array of one config', function() {
       expect(env.callbackMock).to.have.been.calledOnce;
       expect(env.callbackMock.firstCall.args[1]).to.deep.equal([
         {
           name: 'example-1',
-          config: { entry: 'my-first-example' }
+          config: 'node_modules/raw-loader/examples/example-1/webpack.config.js'
         },
         {
           name: 'example-2',
-          config: { entry: 'my-second-example' }
+          config: 'node_modules/raw-loader/examples/example-2/webpack.config.js'
         },
         {
           name: 'example-3',
-          config: { entry: 'my-third-example' }
+          config: 'node_modules/raw-loader/examples/example-3/webpack.config.js'
         }
       ]);
     });
@@ -111,10 +90,6 @@ describe('getDependencyExamples', function() {
   describe('when no examples found', function() {
     beforeEach(function() {
       env.globCallback(null, []);
-    });
-
-    it('does not retrieve example config', function() {
-      expect(env.retrieveStub).not.to.have.been.called;
     });
 
     it('calls the callback with empty array', function() {

--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -1,22 +1,23 @@
-export default function(config, callback) {
-  const webpack = require('webpack');
-  const compiler = webpack(config);
+import childProcess from 'child_process';
 
-  compiler.run(function(err, stats) {
+const webpack = './node_modules/webpack/bin/webpack.js';
+
+export default function(configPath, callback) {
+  const compilerCommand = `${webpack} --config ${configPath}`;
+
+  childProcess.exec(compilerCommand, function(err, stdout, stderr) {
     if (err) {
       callback(['Error running webpack', err]);
       return;
     }
 
-    const jsonStats = stats.toJson();
-
-    if (jsonStats.errors.length > 0) {
-      callback(['Errors output during compilation', jsonStats.errors]);
+    if (stderr) {
+      callback(['Errors output during compilation', stderr]);
       return;
     }
 
-    if (jsonStats.warnings.length > 0) {
-      callback(['Warnings output during compilation', jsonStats.warnings]);
+    if (stdout.toLowerCase().indexOf('error') > -1) {
+      callback(['Errors detected in compilation', stdout]);
       return;
     }
 

--- a/lib/run-dependency-with-webpack/test/index.spec.js
+++ b/lib/run-dependency-with-webpack/test/index.spec.js
@@ -11,27 +11,26 @@ describe('runDependencyWithWebpack', function() {
   let env;
   beforeEach(function() {
     env = {};
-    env.compilerRunMock = sinon.mock();
-    env.webpackStub = sinon.stub().returns({
-      run: env.compilerRunMock
-    });
+    env.childProcessStub = {
+      exec: sinon.mock()
+    };
     env.callbackMock = sinon.mock();
     env.runDependencyWithWebpack = proxyquireStrict('../', {
-      'webpack': env.webpackStub,
+      'child_process': env.childProcessStub,
     }).default;
-    env.config = { entry: 'my-app' };
+    env.config = 'node_modules/raw-loader/examples/webpack.config.js';
     env.runDependencyWithWebpack(env.config, env.callbackMock);
-    env.compilerRunCallback = env.compilerRunMock.firstCall.args[0];
+    env.childProcessCallback = env.childProcessStub.exec.firstCall.args[1];
   });
 
-  it('creates a webpack compiler', function() {
-    expect(env.webpackStub).to.have.been.calledOnce;
-    expect(env.webpackStub).to.have.been.calledWith(env.config);
+  it('executes webpack', function() {
+    expect(env.childProcessStub.exec).to.have.been.calledOnce;
+    expect(env.childProcessStub.exec).to.have.been.calledWith('./node_modules/webpack/bin/webpack.js --config node_modules/raw-loader/examples/webpack.config.js');
   });
 
-  describe('when error running compiler', function() {
+  describe('when error executing webpack', function() {
     beforeEach(function() {
-      env.compilerRunCallback(new Error('test'));
+      env.childProcessCallback(new Error('test'), '', '');
     });
 
     it('calls the callback with error message', function() {
@@ -43,46 +42,37 @@ describe('runDependencyWithWebpack', function() {
     });
   });
 
-  describe('when errors output from compiler', function() {
+  describe('when webpack build causes error', function() {
     beforeEach(function() {
-      const statsWithErrors = {
-        toJson: () => ({ errors: ['error output'], warnings: [] })
-      };
-      env.compilerRunCallback(null, statsWithErrors);
+      env.childProcessCallback(null, '', 'error output');
     });
 
     it('calls the callback with error message', function() {
       expect(env.callbackMock).to.have.been.calledOnce;
       expect(env.callbackMock).to.have.been.calledWith([
         'Errors output during compilation',
-        ['error output']
+        'error output'
       ]);
     });
   });
 
-  describe('when warnings output from compiler', function() {
+  describe('when webpack outputs error message', function() {
     beforeEach(function() {
-      const statsWithWarnings = {
-        toJson: () => ({ errors: [], warnings: ['warning output'] })
-      };
-      env.compilerRunCallback(null, statsWithWarnings);
+      env.childProcessCallback(null, 'An error has occurred', '');
     });
 
-    it('calls the callback with warning message', function() {
+    it('calls the callback with error message', function() {
       expect(env.callbackMock).to.have.been.calledOnce;
       expect(env.callbackMock).to.have.been.calledWith([
-        'Warnings output during compilation',
-        ['warning output']
+        'Errors detected in compilation',
+        'An error has occurred'
       ]);
     });
   });
 
-  describe('when compilation is successful', function() {
+  describe('when webpack build is successful', function() {
     beforeEach(function() {
-      const cleanStats = {
-        toJson: () => ({ errors: [], warnings: [] })
-      };
-      env.compilerRunCallback(null, cleanStats);
+      env.childProcessCallback(null, '', '');
     });
 
     it('calls the callback with error message', function() {


### PR DESCRIPTION
Call webpack from command line. This prevents caching issues seen when using require to call webpacks programatic interface.