### PR TITLE
Simplify version files to mapping

### DIFF
--- a/squawk/dependency-versions.json
+++ b/squawk/dependency-versions.json
@@ -1,4 +1,0 @@
-[
-  "raw-loader@latest",
-  "json-loader@latest"
-]

--- a/squawk/index.js
+++ b/squawk/index.js
@@ -4,15 +4,14 @@ import _ from 'underscore';
 import chalk from 'chalk';
 import Table from 'cli-table2';
 import getLogger from '../lib/logger';
-import webpackVersions from './webpack-versions';
-import dependencyVersions from './dependency-versions';
+import versionMapping from './webpack-to-dependency-versions';
 import canary from '../lib';
 
 const squawk = Promise.promisify(canary);
 const options = { loglevel: 'silent' };
 const logger = getLogger();
 const createRunList = function() {
-  const nestedRunList = _.map(webpackVersions, function(webpackVersion) {
+  const nestedRunList = _.map(versionMapping, function(dependencyVersions, webpackVersion) {
     return _.map(dependencyVersions, function(dependencyVersion) {
       return {
         webpack: webpackVersion,

--- a/squawk/webpack-to-dependency-versions.json
+++ b/squawk/webpack-to-dependency-versions.json
@@ -1,0 +1,14 @@
+{
+  "v1.14.0": [
+    "raw-loader@latest",
+    "json-loader@latest"
+  ],
+  "v2.2.0-rc.5": [
+    "raw-loader@latest",
+    "json-loader@latest"
+  ],
+  "webpack/webpack#master": [
+    "raw-loader@latest",
+    "json-loader@latest"
+  ]
+}

--- a/squawk/webpack-versions.json
+++ b/squawk/webpack-versions.json
@@ -1,6 +1,0 @@
-[
-  "v1.14.0",
-  "v2.2.0-rc.5",
-  "webpack/webpack#master"
-]
-


### PR DESCRIPTION
Simplify into one mapping file - this will allow better control over which versions run under which webpack versions and ignoring older webpack versions for newer dependencies.