### PR TITLE
Support running example scripts

### DIFF
--- a/lib/generate-install-object/install-object.js
+++ b/lib/generate-install-object/install-object.js
@@ -1,3 +1,4 @@
+import url from 'url';
 import _ from 'underscore';
 import semver from 'semver';
 import sources from './sources';
@@ -19,20 +20,23 @@ const dependencyWithVersion = function(dependency) {
   };
 };
 
-const dependencyFromRepo = function(dependency) {
-  if (dependency[0] === '@') return {};
-  if (dependency.indexOf('/') < 0) return {};
+const dependencyFromRepo = function(dependencyString) {
+  if (dependencyString[0] === '@') return {};
+  if (dependencyString.indexOf('/') < 0) return {};
 
-  const dependencyPieces = dependency.split('#');
-  const branch = dependencyPieces[1];
-  const dependencyNamePieces = dependencyPieces[0].split('/')
-  const dependencyName = _.last(dependencyNamePieces);
-  const dependencyPrefix = _.initial(dependencyNamePieces).join('/');
+  const dependency = url.parse(dependencyString);
+  const branch = _.isNull(dependency.hash) ? undefined : dependency.hash.replace(/^#/, '');
+  const dependencyNamePieces = dependency.path.replace(/^\//, '').split('/');
+  const dependencyName = dependencyNamePieces[1];
+  const domain = `${dependency.protocol}//${dependency.host}`;
+  const dependencyPrefix = (_.isNull(dependency.host) ? '' : `${domain}/`) + dependencyNamePieces[0];
+  const dependencySuffix = dependencyNamePieces.slice(2).join('/');
 
   return {
     name: dependencyName,
     branch: branch,
     prefix: dependencyPrefix,
+    suffix: dependencySuffix,
     source: sources.repository
   };
 };
@@ -72,7 +76,8 @@ class InstallObject {
     }
 
     if (this.source === sources.repository) {
-      return `${this.prefix}/${this.name}${this.getBranchSuffix()}`;
+      const suffix = _.isEmpty(this.suffix) ? '' : `/${this.suffix}`;
+      return `${this.prefix}/${this.name}${this.getBranchSuffix()}${suffix}`;
     }
 
     return this.name;

--- a/lib/generate-install-object/test/intall-object.spec.js
+++ b/lib/generate-install-object/test/intall-object.spec.js
@@ -146,4 +146,26 @@ describe('InstallObject', function() {
       });
     });
   });
+
+  describe('Install from remote tar file URL', function() {
+    beforeEach(function() {
+      env.installObject = new InstallObject('https://github.com/webpack/webpack-dev-server/archive/v2.2.0.tar.gz')
+    });
+
+    it('has the correct string value', function() {
+      expect(env.installObject.toString()).to.equal('https://github.com/webpack/webpack-dev-server/archive/v2.2.0.tar.gz');
+    });
+
+    it('has the correct local name', function() {
+      expect(env.installObject.toLocalName()).to.equal('webpack-dev-server');
+    });
+
+    it('has version', function() {
+      expect(env.installObject.hasVersion()).to.equal(false);
+    });
+
+    it('does not have branch', function() {
+      expect(env.installObject.hasBranch()).to.equal(false);
+    });
+  });
 });

--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -1,12 +1,30 @@
 import childProcess from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import _ from 'underscore';
 
 const webpack = './node_modules/webpack/bin/webpack.js';
 
-export default function(configPath, callback) {
-  const compilerCommand = `${webpack} --config ${configPath}`;
+const getExampleCompilerCommand = function(exampleDirectory) {
+  const commandMatchPattern = /```([\s\S]+?)```/;
 
-  childProcess.exec(compilerCommand, function(err, stdout, stderr) {
-    if (err) {
+  const readme = fs.readFileSync(`${exampleDirectory}/README.md`); // eslint-disable-line no-sync
+  const command = commandMatchPattern.exec(readme);
+  if (!_.isArray(command)) return command;
+  return command[1]
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
+};
+
+export default function(configPath, callback) {
+  const exampleDirectory = path.dirname(configPath);
+  const defaultCompilerCommand = `${webpack} --config ./webpack.config.js`;
+  const exampleCompilerCommand = getExampleCompilerCommand(exampleDirectory);
+  const compilerCommand = _.isString(exampleCompilerCommand) ? exampleCompilerCommand : defaultCompilerCommand;
+
+  childProcess.exec(compilerCommand, { cwd: exampleDirectory, timeout: 5000 }, function(err, stdout, stderr) {
+    if (err && stdout.indexOf('webpack: bundle is now VALID') === -1) {
       callback(['Error running webpack', err, stdout]);
       return;
     }

--- a/lib/run-dependency-with-webpack/test/index.spec.js
+++ b/lib/run-dependency-with-webpack/test/index.spec.js
@@ -9,76 +9,109 @@ const proxyquireStrict = proxyquire.noCallThru();
 
 describe('runDependencyWithWebpack', function() {
   let env;
+
   beforeEach(function() {
     env = {};
     env.childProcessStub = {
       exec: sinon.mock()
     };
+    env.fsStub = {
+      readFileSync: sinon.mock()
+    };
     env.callbackMock = sinon.mock();
     env.runDependencyWithWebpack = proxyquireStrict('../', {
       'child_process': env.childProcessStub,
+      'fs': env.fsStub
     }).default;
     env.config = 'node_modules/raw-loader/examples/webpack.config.js';
-    env.runDependencyWithWebpack(env.config, env.callbackMock);
-    env.childProcessCallback = env.childProcessStub.exec.firstCall.args[1];
   });
 
-  it('executes webpack', function() {
-    expect(env.childProcessStub.exec).to.have.been.calledOnce;
-    expect(env.childProcessStub.exec).to.have.been.calledWith('./node_modules/webpack/bin/webpack.js --config node_modules/raw-loader/examples/webpack.config.js');
-  });
-
-  describe('when error executing webpack', function() {
+  describe('when readme file does not contain command', function() {
     beforeEach(function() {
-      env.childProcessCallback(new Error('test'), '', '');
+      env.fsStub.readFileSync.returns('foo'); // eslint-disable-line no-sync
+      env.runDependencyWithWebpack(env.config, env.callbackMock);
+      env.childProcessCallback = env.childProcessStub.exec.firstCall.args[2];
     });
 
-    it('calls the callback with error message', function() {
-      expect(env.callbackMock).to.have.been.calledOnce;
-      expect(env.callbackMock).to.have.been.calledWith([
-        'Error running webpack',
-        new Error(),
-        ''
-      ]);
-    });
-  });
-
-  describe('when webpack build causes error', function() {
-    beforeEach(function() {
-      env.childProcessCallback(null, '', 'error output');
-    });
-
-    it('calls the callback with error message', function() {
-      expect(env.callbackMock).to.have.been.calledOnce;
-      expect(env.callbackMock).to.have.been.calledWith([
-        'Errors output during compilation',
-        'error output'
-      ]);
+    it('executes default webpack compile', function() {
+      expect(env.childProcessStub.exec).to.have.been.calledOnce;
+      expect(env.childProcessStub.exec).to.have.been.calledWith('./node_modules/webpack/bin/webpack.js --config ./webpack.config.js');
+      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: "node_modules/raw-loader/examples", timeout: 5000 });
     });
   });
 
-  describe('when webpack outputs error message', function() {
+  describe('when readme file does contain command', function() {
     beforeEach(function() {
-      env.childProcessCallback(null, 'An error has occurred', '');
+      env.fsStub.readFileSync.returns('```shell\ncat ./package.json;\n```'); // eslint-disable-line no-sync
+      env.runDependencyWithWebpack(env.config, env.callbackMock);
+      env.childProcessCallback = env.childProcessStub.exec.firstCall.args[2];
     });
 
-    it('calls the callback with error message', function() {
-      expect(env.callbackMock).to.have.been.calledOnce;
-      expect(env.callbackMock).to.have.been.calledWith([
-        'Errors detected in compilation',
-        'An error has occurred'
-      ]);
+    it('executes default webpack compile', function() {
+      expect(env.childProcessStub.exec).to.have.been.calledOnce;
+      expect(env.childProcessStub.exec).to.have.been.calledWith('cat ./package.json;');
+      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: "node_modules/raw-loader/examples", timeout: 5000 });
     });
   });
 
-  describe('when webpack build is successful', function() {
+  describe('when executing', function() {
     beforeEach(function() {
-      env.childProcessCallback(null, '', '');
+      env.runDependencyWithWebpack(env.config, env.callbackMock);
+      env.childProcessCallback = env.childProcessStub.exec.firstCall.args[2];
     });
 
-    it('calls the callback with error message', function() {
-      expect(env.callbackMock).to.have.been.calledOnce;
-      expect(env.callbackMock).to.have.been.calledWithExactly();
+    describe('and error executing webpack', function() {
+      beforeEach(function() {
+        env.childProcessCallback(new Error('test'), '', '');
+      });
+
+      it('calls the callback with error message', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith([
+          'Error running webpack',
+          new Error(),
+          ''
+        ]);
+      });
+    });
+
+    describe('and webpack build causes error', function() {
+      beforeEach(function() {
+        env.childProcessCallback(null, '', 'error output');
+      });
+
+      it('calls the callback with error message', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith([
+          'Errors output during compilation',
+          'error output'
+        ]);
+      });
+    });
+
+    describe('and webpack outputs error message', function() {
+      beforeEach(function() {
+        env.childProcessCallback(null, 'An error has occurred', '');
+      });
+
+      it('calls the callback with error message', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith([
+          'Errors detected in compilation',
+          'An error has occurred'
+        ]);
+      });
+    });
+
+    describe('and webpack build is successful', function() {
+      beforeEach(function() {
+        env.childProcessCallback(null, '', '');
+      });
+
+      it('calls the callback with error message', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWithExactly();
+      });
     });
   });
 });

--- a/squawk/webpack-to-dependency-versions.json
+++ b/squawk/webpack-to-dependency-versions.json
@@ -3,12 +3,14 @@
     "raw-loader@latest",
     "json-loader@latest"
   ],
-  "v2.2.0-rc.5": [
+  "v2.2.0": [
     "raw-loader@latest",
-    "json-loader@latest"
+    "json-loader@latest",
+    "https://github.com/webpack/webpack-dev-server/archive/v2.2.0.tar.gz"
   ],
   "webpack/webpack#master": [
     "raw-loader@latest",
-    "json-loader@latest"
+    "json-loader@latest",
+    "https://github.com/webpack/webpack-dev-server/archive/master.tar.gz"
   ]
 }


### PR DESCRIPTION
This PR reads the first script tag from the corresponding example readme and runs this, killing the processes after 5 seconds. This allows the webpack-dev-server examples to be run with the latest webpack, which has now been added to the dependencies to test.
Support for tar files was added to allow pulling in a version which also includes the examples.