### PR TITLE
Update canary to successfully run most webpack dev server examples

### DIFF
--- a/lib/install-webpack-and-dependency/index.js
+++ b/lib/install-webpack-and-dependency/index.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import childProcess from 'child_process';
 
 export default function(webpackSetup, dependencySetup, callback) {
@@ -20,6 +21,14 @@ export default function(webpackSetup, dependencySetup, callback) {
       return;
     }
 
-    callback();
+    const dependencyInstallLocation = path.join('node_modules', dependencySetup.toLocalName());
+    childProcess.exec('npm install', { cwd: dependencyInstallLocation }, function(err) {
+      if (err) {
+        callback(['Error calling install command for dependency build', err]);
+        return;
+      }
+
+      callback();
+    });
   });
 }

--- a/lib/install-webpack-and-dependency/test/index.spec.js
+++ b/lib/install-webpack-and-dependency/test/index.spec.js
@@ -13,14 +13,14 @@ describe('installWebpackAndDependency', function() {
   beforeEach(function() {
     env = {};
     env.childProcessStub = {
-      exec: sinon.mock()
+      exec: sinon.mock().atMost(2)
     };
     env.callbackMock = sinon.mock();
     env.installWebpackAndDependency = proxyquireStrict('../', {
       'child_process': env.childProcessStub,
     }).default;
     env.installWebpackAndDependency(new InstallObject('webpack@2.3.4'), new InstallObject('raw-loader@1.2.3'), env.callbackMock);
-    env.childProcessExecCallback = env.childProcessStub.exec.firstCall.args[1];
+    env.webpackInstallCallback = env.childProcessStub.exec.firstCall.args[1];
   });
 
   it('calls npm install with correct values', function() {
@@ -30,7 +30,7 @@ describe('installWebpackAndDependency', function() {
 
   describe('when error installing', function() {
     beforeEach(function() {
-      env.childProcessExecCallback(new Error('test'), '', undefined);
+      env.webpackInstallCallback(new Error('test'), '', undefined);
     });
 
     it('calls the callback with error message', function() {
@@ -44,7 +44,7 @@ describe('installWebpackAndDependency', function() {
 
   describe('when outputted error messages', function() {
     beforeEach(function() {
-      env.childProcessExecCallback(null, '', 'child processed error message');
+      env.webpackInstallCallback(null, '', 'child processed error message');
     });
 
     it('calls the callback with error message', function() {
@@ -63,12 +63,33 @@ describe('installWebpackAndDependency', function() {
         ├── raw-loader@1.2.3
         └── webpack@2.3.4
       `;
-      env.childProcessExecCallback(null, installedOutput, undefined);
+      env.webpackInstallCallback(null, installedOutput, undefined);
+      env.examplesInstallCallback = env.childProcessStub.exec.secondCall.args[2];
     });
 
-    it('calls the callback with error message', function() {
-      expect(env.callbackMock).to.have.been.calledOnce;
-      expect(env.callbackMock).to.have.been.calledWithExactly();
+    describe('and examples install errors out', function() {
+      beforeEach(function() {
+        env.examplesInstallCallback(new Error('test'));
+      });
+
+      it('calls the callback with error message', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWith([
+          'Error calling install command for dependency build',
+          new Error()
+        ]);
+      });
+    });
+
+    describe('and examples install finishes', function() {
+      beforeEach(function() {
+        env.examplesInstallCallback();
+      });
+
+      it('calls the callback', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWithExactly();
+      });
     });
   });
 
@@ -78,7 +99,7 @@ describe('installWebpackAndDependency', function() {
         my-project@1.0.0 /path/to/my-project
         └── webpack@2.3.4
       `;
-      env.childProcessExecCallback(null, env.installedOutput, undefined);
+      env.webpackInstallCallback(null, env.installedOutput, undefined);
     });
 
     it('calls the callback with error message', function() {

--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -4,6 +4,21 @@ import path from 'path';
 import _ from 'underscore';
 
 const webpack = './node_modules/webpack/bin/webpack.js';
+const replacementMapping = {
+  'node ': 'node --no-warnings ',
+  '<insert local ip>': '127.0.0.1'
+};
+
+const applyReplacements = function(exampleCompilerCommand) {
+  return _.reduce(replacementMapping, function(command, replacement, replaceable) {
+    return command.replace(replaceable, replacement);
+  }, exampleCompilerCommand)
+};
+
+const containsSuccessMessage = function(stdout) {
+  return stdout.indexOf('webpack: bundle is now VALID') > -1 ||
+         stdout.indexOf('webpack: Compiled successfully') > -1;
+};
 
 const getExampleCompilerCommand = function(exampleDirectory) {
   const commandMatchPattern = /```([\s\S]+?)```/;
@@ -11,20 +26,24 @@ const getExampleCompilerCommand = function(exampleDirectory) {
   const readme = fs.readFileSync(`${exampleDirectory}/README.md`); // eslint-disable-line no-sync
   const command = commandMatchPattern.exec(readme);
   if (!_.isArray(command)) return command;
-  return command[1]
+  const exampleCompilerCommand = command[1]
     .split('\n')
     .slice(1, -1)
     .join('\n');
+  return applyReplacements(exampleCompilerCommand);
 };
 
-export default function(configPath, callback) {
+export default function(configPath, completeExample) {
+  const callback = function(...args) {
+    _.delay(completeExample, 500, ...args);
+  };
   const exampleDirectory = path.dirname(configPath);
   const defaultCompilerCommand = `${webpack} --config ./webpack.config.js`;
   const exampleCompilerCommand = getExampleCompilerCommand(exampleDirectory);
   const compilerCommand = _.isString(exampleCompilerCommand) ? exampleCompilerCommand : defaultCompilerCommand;
 
   childProcess.exec(compilerCommand, { cwd: exampleDirectory, timeout: 5000 }, function(err, stdout, stderr) {
-    if (err && stdout.indexOf('webpack: bundle is now VALID') === -1) {
+    if (err && !containsSuccessMessage(stdout)) {
       callback(['Error running webpack', err, stdout]);
       return;
     }

--- a/lib/run-dependency-with-webpack/test/index.spec.js
+++ b/lib/run-dependency-with-webpack/test/index.spec.js
@@ -12,6 +12,7 @@ describe('runDependencyWithWebpack', function() {
 
   beforeEach(function() {
     env = {};
+    env.clock = sinon.useFakeTimers();
     env.childProcessStub = {
       exec: sinon.mock()
     };
@@ -26,17 +27,20 @@ describe('runDependencyWithWebpack', function() {
     env.config = 'node_modules/raw-loader/examples/webpack.config.js';
   });
 
+  afterEach(function() {
+    env.clock.restore();
+  });
+
   describe('when readme file does not contain command', function() {
     beforeEach(function() {
       env.fsStub.readFileSync.returns('foo'); // eslint-disable-line no-sync
       env.runDependencyWithWebpack(env.config, env.callbackMock);
-      env.childProcessCallback = env.childProcessStub.exec.firstCall.args[2];
     });
 
     it('executes default webpack compile', function() {
       expect(env.childProcessStub.exec).to.have.been.calledOnce;
       expect(env.childProcessStub.exec).to.have.been.calledWith('./node_modules/webpack/bin/webpack.js --config ./webpack.config.js');
-      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: "node_modules/raw-loader/examples", timeout: 5000 });
+      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: 'node_modules/raw-loader/examples', timeout: 5000 });
     });
   });
 
@@ -44,13 +48,12 @@ describe('runDependencyWithWebpack', function() {
     beforeEach(function() {
       env.fsStub.readFileSync.returns('```shell\ncat ./package.json;\n```'); // eslint-disable-line no-sync
       env.runDependencyWithWebpack(env.config, env.callbackMock);
-      env.childProcessCallback = env.childProcessStub.exec.firstCall.args[2];
     });
 
     it('executes default webpack compile', function() {
       expect(env.childProcessStub.exec).to.have.been.calledOnce;
       expect(env.childProcessStub.exec).to.have.been.calledWith('cat ./package.json;');
-      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: "node_modules/raw-loader/examples", timeout: 5000 });
+      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: 'node_modules/raw-loader/examples', timeout: 5000 });
     });
   });
 
@@ -63,6 +66,7 @@ describe('runDependencyWithWebpack', function() {
     describe('and error executing webpack', function() {
       beforeEach(function() {
         env.childProcessCallback(new Error('test'), '', '');
+        env.clock.tick(510);
       });
 
       it('calls the callback with error message', function() {
@@ -75,9 +79,22 @@ describe('runDependencyWithWebpack', function() {
       });
     });
 
+    describe('and execution times out with valid webpack build', function() {
+      beforeEach(function() {
+        env.childProcessCallback(new Error('timed out'), 'webpack: Compiled successfully', '');
+        env.clock.tick(510);
+      });
+
+      it('calls the callback', function() {
+        expect(env.callbackMock).to.have.been.calledOnce;
+        expect(env.callbackMock).to.have.been.calledWithExactly();
+      });
+    });
+
     describe('and webpack build causes error', function() {
       beforeEach(function() {
         env.childProcessCallback(null, '', 'error output');
+        env.clock.tick(510);
       });
 
       it('calls the callback with error message', function() {
@@ -92,6 +109,7 @@ describe('runDependencyWithWebpack', function() {
     describe('and webpack outputs error message', function() {
       beforeEach(function() {
         env.childProcessCallback(null, 'An error has occurred', '');
+        env.clock.tick(510);
       });
 
       it('calls the callback with error message', function() {
@@ -106,9 +124,10 @@ describe('runDependencyWithWebpack', function() {
     describe('and webpack build is successful', function() {
       beforeEach(function() {
         env.childProcessCallback(null, '', '');
+        env.clock.tick(510);
       });
 
-      it('calls the callback with error message', function() {
+      it('calls the callback', function() {
         expect(env.callbackMock).to.have.been.calledOnce;
         expect(env.callbackMock).to.have.been.calledWithExactly();
       });

--- a/squawk/webpack-to-dependency-versions.json
+++ b/squawk/webpack-to-dependency-versions.json
@@ -1,16 +1,11 @@
 {
   "v1.14.0": [
-    "raw-loader@latest",
-    "json-loader@latest"
+    "https://github.com/webpack/webpack-dev-server/archive/v1.16.3.tar.gz"
   ],
-  "v2.2.0": [
-    "raw-loader@latest",
-    "json-loader@latest",
-    "https://github.com/webpack/webpack-dev-server/archive/v2.2.0.tar.gz"
+  "v2.2.1": [
+    "https://github.com/webpack/webpack-dev-server/archive/v2.3.0.tar.gz"
   ],
   "webpack/webpack#master": [
-    "raw-loader@latest",
-    "json-loader@latest",
     "https://github.com/webpack/webpack-dev-server/archive/master.tar.gz"
   ]
 }


### PR DESCRIPTION
Update canary to run latest dev server release on latest webpack release. The config has been updated to try and run the latest v1 dev server on webpack v1, and latest masters of each.

Running this on travis should show if a) those work and b) if there are any setup issues with travis (port conflicts, etc.) which this branch should also aim to fix.

__Update:__ Two issues which will not be fixed as part of this branch
1. Use `spawn` over `exec`
    > on Linux, child processes of child processes will not be terminated when attempting to kill their parent.

    This has lead to the dev server examples not being killed and hanging on to ports, failing future examples from even running.
2. Dev server lazy load requires that the page be visited before executing. Page visiting (with JS execution) will need to be added to the example run if a URL is provided in the output.