### PR TITLE
Use spawn for example run and open local URLs

### DIFF
--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -1,6 +1,7 @@
 import childProcess from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import url from 'url';
 import _ from 'underscore';
 
 const webpack = './node_modules/webpack/bin/webpack.js';
@@ -18,6 +19,28 @@ const applyReplacements = function(exampleCompilerCommand) {
 const containsSuccessMessage = function(stdout) {
   return stdout.indexOf('webpack: bundle is now VALID') > -1 ||
          stdout.indexOf('webpack: Compiled successfully') > -1;
+};
+
+const getOutputUrl = function(stdout) {
+  const urlMatchPattern = /https?:\/\/[-a-zA-Z0-9@:%._+~#=]{2,256}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/gi;
+  const urlMatch = urlMatchPattern.exec(stdout);
+  if (!_.isArray(urlMatch)) return null;
+
+  const address = url.parse(urlMatch[0]);
+  if (!_.contains(['localhost', '127.0.0.1'], address.hostname)) {
+    return null
+  }
+
+  return urlMatch[0];
+};
+
+const executeUrl = function(address) {
+  childProcess.exec(`phantomjs ./scripts/open-url.js '${address}'`, {
+    env: {
+      QT_QPA_PLATFORM: 'offscreen'
+    },
+    timeout: 2000
+  });
 };
 
 const getExampleCompilerCommand = function(exampleDirectory) {
@@ -53,7 +76,7 @@ export default function(configPath, completeExample) {
 
   exampleRunTimeout = setTimeout(function() {
     killExample();
-  }, 5000);
+  }, 10000);
 
   exampleRun.stdout.on('data', (data) => {
     const stdout = data.toString();
@@ -66,6 +89,12 @@ export default function(configPath, completeExample) {
     if (containsSuccessMessage(stdout)) {
       killExample();
       callback();
+      return;
+    }
+
+    const outputUrl = getOutputUrl(stdout);
+    if (_.isString(outputUrl) && !_.isEmpty(outputUrl)) {
+      executeUrl(outputUrl);
     }
   });
 

--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -34,30 +34,52 @@ const getExampleCompilerCommand = function(exampleDirectory) {
 };
 
 export default function(configPath, completeExample) {
-  const callback = function(...args) {
-    _.delay(completeExample, 500, ...args);
-  };
+  const callback = _.once(function(...args) {
+    _.delay(completeExample, 100, ...args);
+  });
   const exampleDirectory = path.dirname(configPath);
   const defaultCompilerCommand = `${webpack} --config ./webpack.config.js`;
   const exampleCompilerCommand = getExampleCompilerCommand(exampleDirectory);
   const compilerCommand = _.isString(exampleCompilerCommand) ? exampleCompilerCommand : defaultCompilerCommand;
 
-  childProcess.exec(compilerCommand, { cwd: exampleDirectory, timeout: 5000 }, function(err, stdout, stderr) {
-    if (err && !containsSuccessMessage(stdout)) {
-      callback(['Error running webpack', err, stdout]);
-      return;
-    }
+  const [command, ...commandArgs] = compilerCommand.split(' ');
+  const exampleRun = childProcess.spawn(command, commandArgs, { cwd: exampleDirectory });
+  let exampleRunTimeout = null;
 
-    if (stderr) {
-      callback(['Errors output during compilation', stderr]);
-      return;
-    }
+  const killExample = function() {
+    clearTimeout(exampleRunTimeout);
+    exampleRun.kill();
+  };
 
+  exampleRunTimeout = setTimeout(function() {
+    killExample();
+  }, 5000);
+
+  exampleRun.stdout.on('data', (data) => {
+    const stdout = data.toString();
     if (stdout.toLowerCase().indexOf('error') > -1) {
+      killExample();
       callback(['Errors detected in compilation', stdout]);
       return;
     }
 
-    callback();
+    if (containsSuccessMessage(stdout)) {
+      killExample();
+      callback();
+    }
+  });
+
+  exampleRun.stderr.on('data', (data) => {
+    const stderr = data.toString();
+    killExample();
+    callback(['Errors output during compilation', stderr]);
+  });
+
+  exampleRun.on('close', () => {
+    callback(['Unable to detect successful compilation']);
+  });
+
+  exampleRun.on('error', (err) => {
+    callback(['Failed to run example', err]);
   });
 }

--- a/lib/run-dependency-with-webpack/test/index.spec.js
+++ b/lib/run-dependency-with-webpack/test/index.spec.js
@@ -13,8 +13,14 @@ describe('runDependencyWithWebpack', function() {
   beforeEach(function() {
     env = {};
     env.clock = sinon.useFakeTimers();
+    env.mockProcess = {
+      on: sinon.stub(),
+      kill: sinon.stub(),
+      stdout: { on: sinon.stub() },
+      stderr: { on: sinon.stub() }
+    };
     env.childProcessStub = {
-      exec: sinon.mock()
+      spawn: sinon.mock().returns(env.mockProcess)
     };
     env.fsStub = {
       readFileSync: sinon.mock()
@@ -38,98 +44,141 @@ describe('runDependencyWithWebpack', function() {
     });
 
     it('executes default webpack compile', function() {
-      expect(env.childProcessStub.exec).to.have.been.calledOnce;
-      expect(env.childProcessStub.exec).to.have.been.calledWith('./node_modules/webpack/bin/webpack.js --config ./webpack.config.js');
-      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: 'node_modules/raw-loader/examples', timeout: 5000 });
+      expect(env.childProcessStub.spawn).to.have.been.calledOnce;
+      expect(env.childProcessStub.spawn).to.have.been.calledWith('./node_modules/webpack/bin/webpack.js')
+      expect(env.childProcessStub.spawn.firstCall.args[1]).to.deep.equal(['--config', './webpack.config.js']);
+      expect(env.childProcessStub.spawn.firstCall.args[2]).to.deep.equal({ cwd: 'node_modules/raw-loader/examples' });
     });
   });
 
   describe('when readme file does contain command', function() {
     beforeEach(function() {
-      env.fsStub.readFileSync.returns('```shell\ncat ./package.json;\n```'); // eslint-disable-line no-sync
+      env.fsStub.readFileSync.returns('```shell\ncat ./package.json\n```'); // eslint-disable-line no-sync
       env.runDependencyWithWebpack(env.config, env.callbackMock);
     });
 
     it('executes default webpack compile', function() {
-      expect(env.childProcessStub.exec).to.have.been.calledOnce;
-      expect(env.childProcessStub.exec).to.have.been.calledWith('cat ./package.json;');
-      expect(env.childProcessStub.exec.firstCall.args[1]).to.deep.equal({ cwd: 'node_modules/raw-loader/examples', timeout: 5000 });
+      expect(env.childProcessStub.spawn).to.have.been.calledOnce;
+      expect(env.childProcessStub.spawn).to.have.been.calledWith('cat')
+      expect(env.childProcessStub.spawn.firstCall.args[1]).to.deep.equal(['./package.json']);
+      expect(env.childProcessStub.spawn.firstCall.args[2]).to.deep.equal({ cwd: 'node_modules/raw-loader/examples' });
     });
   });
 
   describe('when executing', function() {
     beforeEach(function() {
       env.runDependencyWithWebpack(env.config, env.callbackMock);
-      env.childProcessCallback = env.childProcessStub.exec.firstCall.args[2];
+      env.processCloseHandler = env.mockProcess.on.firstCall.args[1];
+      env.processErrorHandler = env.mockProcess.on.secondCall.args[1];
+      env.errorHandler = env.mockProcess.stderr.on.firstCall.args[1];
+      env.successHandler = env.mockProcess.stdout.on.firstCall.args[1];
     });
 
-    describe('and error executing webpack', function() {
+    describe('and error executing example', function() {
       beforeEach(function() {
-        env.childProcessCallback(new Error('test'), '', '');
-        env.clock.tick(510);
+        env.processErrorHandler('Bad command');
+        env.clock.tick(110);
       });
 
       it('calls the callback with error message', function() {
         expect(env.callbackMock).to.have.been.calledOnce;
         expect(env.callbackMock).to.have.been.calledWith([
-          'Error running webpack',
-          new Error(),
-          ''
+          'Failed to run example',
+          'Bad command'
         ]);
       });
     });
 
-    describe('and execution times out with valid webpack build', function() {
+    describe('and process is closed', function() {
       beforeEach(function() {
-        env.childProcessCallback(new Error('timed out'), 'webpack: Compiled successfully', '');
-        env.clock.tick(510);
+        env.processCloseHandler();
+        env.clock.tick(110);
       });
 
-      it('calls the callback', function() {
+      it('calls the callback with error message', function() {
         expect(env.callbackMock).to.have.been.calledOnce;
-        expect(env.callbackMock).to.have.been.calledWithExactly();
+        expect(env.callbackMock).to.have.been.calledWith([
+          'Unable to detect successful compilation'
+        ]);
       });
     });
 
-    describe('and webpack build causes error', function() {
+    describe('and example run causes an error', function() {
       beforeEach(function() {
-        env.childProcessCallback(null, '', 'error output');
-        env.clock.tick(510);
+        env.errorHandler('Process level error occurred');
+        env.clock.tick(110);
       });
 
       it('calls the callback with error message', function() {
         expect(env.callbackMock).to.have.been.calledOnce;
         expect(env.callbackMock).to.have.been.calledWith([
           'Errors output during compilation',
-          'error output'
+          'Process level error occurred'
         ]);
+      });
+
+      it('exits the example run', function() {
+        expect(env.mockProcess.kill).to.have.been.calledOnce;
       });
     });
 
     describe('and webpack outputs error message', function() {
       beforeEach(function() {
-        env.childProcessCallback(null, 'An error has occurred', '');
-        env.clock.tick(510);
+        env.successHandler('A webpack error has occurred');
+        env.clock.tick(110);
       });
 
       it('calls the callback with error message', function() {
         expect(env.callbackMock).to.have.been.calledOnce;
         expect(env.callbackMock).to.have.been.calledWith([
           'Errors detected in compilation',
-          'An error has occurred'
+          'A webpack error has occurred'
         ]);
+      });
+
+      it('exits the example run', function() {
+        expect(env.mockProcess.kill).to.have.been.calledOnce;
+      });
+    });
+
+    describe('and webpack outputs meta data', function() {
+      beforeEach(function() {
+        env.successHandler('Useful information on build time and size');
+        env.clock.tick(110);
+      });
+
+      it('does not call the callback', function() {
+        expect(env.callbackMock).not.to.have.been.called;
+      });
+
+      it('does not exit the example run', function() {
+        expect(env.mockProcess.kill).not.to.have.been.called;
       });
     });
 
     describe('and webpack build is successful', function() {
       beforeEach(function() {
-        env.childProcessCallback(null, '', '');
-        env.clock.tick(510);
+        env.successHandler('webpack: Compiled successfully');
+        env.clock.tick(110);
       });
 
       it('calls the callback', function() {
         expect(env.callbackMock).to.have.been.calledOnce;
         expect(env.callbackMock).to.have.been.calledWithExactly();
+      });
+
+      it('exits the example run', function() {
+        expect(env.mockProcess.kill).to.have.been.calledOnce;
+      });
+    });
+
+    describe('and build does not complete within 5 seconds', function() {
+      beforeEach(function() {
+        env.clock.tick(5001);
+      });
+
+      it('exits the example run', function() {
+        expect(env.mockProcess.kill).to.have.been.calledOnce;
       });
     });
   });

--- a/lib/run-dependency-with-webpack/test/index.spec.js
+++ b/lib/run-dependency-with-webpack/test/index.spec.js
@@ -14,13 +14,14 @@ describe('runDependencyWithWebpack', function() {
     env = {};
     env.clock = sinon.useFakeTimers();
     env.mockProcess = {
-      on: sinon.stub(),
-      kill: sinon.stub(),
-      stdout: { on: sinon.stub() },
-      stderr: { on: sinon.stub() }
+      on: sinon.mock().atMost(2),
+      kill: sinon.mock(),
+      stdout: { on: sinon.mock() },
+      stderr: { on: sinon.mock() }
     };
     env.childProcessStub = {
-      spawn: sinon.mock().returns(env.mockProcess)
+      spawn: sinon.mock().returns(env.mockProcess),
+      exec: sinon.mock()
     };
     env.fsStub = {
       readFileSync: sinon.mock()
@@ -156,6 +157,47 @@ describe('runDependencyWithWebpack', function() {
       });
     });
 
+    describe('and webpack outputs a URL', function() {
+      describe('which is external', function() {
+        beforeEach(function() {
+          env.successHandler('http://www.example.com');
+          env.clock.tick(110);
+        });
+
+        it('does not open the URL', function() {
+          expect(env.childProcessStub.exec).not.to.have.been.called;
+        });
+
+        it('does not call the callback', function() {
+          expect(env.callbackMock).not.to.have.been.called;
+        });
+
+        it('does not exit the example run', function() {
+          expect(env.mockProcess.kill).not.to.have.been.called;
+        });
+      });
+
+      describe('which is internal', function() {
+        beforeEach(function() {
+          env.successHandler('http://localhost:8080');
+          env.clock.tick(110);
+        });
+
+        it('does not open the URL', function() {
+          expect(env.childProcessStub.exec).to.have.been.calledOnce;
+          expect(env.childProcessStub.exec).to.have.been.calledWith('phantomjs ./scripts/open-url.js \'http://localhost:8080\'');
+        });
+
+        it('does not call the callback', function() {
+          expect(env.callbackMock).not.to.have.been.called;
+        });
+
+        it('does not exit the example run', function() {
+          expect(env.mockProcess.kill).not.to.have.been.called;
+        });
+      });
+    });
+
     describe('and webpack build is successful', function() {
       beforeEach(function() {
         env.successHandler('webpack: Compiled successfully');
@@ -172,9 +214,9 @@ describe('runDependencyWithWebpack', function() {
       });
     });
 
-    describe('and build does not complete within 5 seconds', function() {
+    describe('and build does not complete within 10 seconds', function() {
       beforeEach(function() {
-        env.clock.tick(5001);
+        env.clock.tick(10001);
       });
 
       it('exits the example run', function() {

--- a/scripts/open-url.js
+++ b/scripts/open-url.js
@@ -1,0 +1,2 @@
+var url = require('system').args[1];
+require('webpage').create().open(url, function () { phantom.exit(); });


### PR DESCRIPTION
Solves the two problems found in pull #13 which were that processes on linux were not being killed after the timeout and lazy loading examples required that the URL be visited.
This PR changes the execution to use spawn, which can be killed, and which provides a performance boost of streaming the output so that successful builds can be signed off early. It also makes use of phantomjs to open any local URLs which are output, which will execute code within lazy loading examples.