### PR TITLE
Support both example and examples directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var options = { loglevel: loglevel };
 require('./lib').default(argv.webpack, argv.dependency, options, function(err) {
   if (err) {
     logger.error('Errors have occurred running examples');
+    logger.error(err);
     process.exit(1);
   }
 

--- a/lib/get-dependency-examples/index.js
+++ b/lib/get-dependency-examples/index.js
@@ -1,31 +1,39 @@
 import path from 'path';
+import Promise from 'bluebird';
 import _ from 'underscore';
 import glob from 'glob';
 
+const globPromise = Promise.promisify(glob);
+
 export default function(webpackSetup, dependencySetup, callback) {
   const webpackConfigFilename = 'webpack.config.js';
-  const examplesDirectoryName = 'examples';
-  const dependencyExamplesPath = path.join(dependencySetup.toLocalName(), examplesDirectoryName);
+  const exampleDirectories = ['examples', 'example'];
+  const exampleDirectoryPaths = _.map(exampleDirectories, function(exampleDirectory) {
+    const dependencyExamplesPath = path.join(dependencySetup.toLocalName(), exampleDirectory);
+    return path.join('node_modules', dependencyExamplesPath);
+  });
+  const exampleGlobs = _.map(exampleDirectoryPaths, function(examplePath) {
+    return globPromise(`**/${webpackConfigFilename}`, { cwd: examplePath });
+  });
 
-  const globOptions = {
-    cwd: path.join('node_modules', dependencyExamplesPath)
-  };
+  Promise.all(exampleGlobs).then(function(groupedExamplePaths) {
+    const webpackConfigFilePaths = _.flatten(_.map(groupedExamplePaths, function(examplePathGroup, index) {
+      const exampleDirectory = exampleDirectoryPaths[index];
+      return _.map(examplePathGroup, (examplePath) => ({ examplePath, exampleDirectory }));
+    }));
 
-  glob(`**/${webpackConfigFilename}`, globOptions, function(err, webpackConfigFilePaths) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    const dependencyExamples = _.map(webpackConfigFilePaths, function(webpackConfigFilePath) {
-      const examplesName = path.dirname(webpackConfigFilePath);
+    const dependencyExamples = _.map(webpackConfigFilePaths, function({ examplePath, exampleDirectory }) {
+      const exampleName = path.dirname(examplePath);
 
       return {
-        name: (examplesName === '.') ? undefined : examplesName,
-        config: path.join('node_modules', dependencyExamplesPath, webpackConfigFilePath)
+        name: (exampleName === '.') ? undefined : exampleName,
+        config: path.join(exampleDirectory, examplePath)
       }
     });
 
     callback(null, dependencyExamples);
+  })
+  .catch(function(err) {
+    callback(err);
   });
 }

--- a/lib/get-dependency-examples/test/index.spec.js
+++ b/lib/get-dependency-examples/test/index.spec.js
@@ -12,39 +12,43 @@ describe('getDependencyExamples', function() {
   let env;
   beforeEach(function() {
     env = {};
-    env.globMock = sinon.mock();
+    env.globMock = sinon.mock().atMost(2);
     env.callbackMock = sinon.mock();
     env.getDependencyExamples = proxyquireStrict('../', {
       'glob': env.globMock
     }).default;
     env.getDependencyExamples(new InstallObject('webpack@2.3.4'), new InstallObject('raw-loader@1.2.3'), env.callbackMock);
-    env.globCallback = env.globMock.firstCall.args[2];
+    env.examplesGlobCallback = env.globMock.firstCall.args[2];
+    env.exampleGlobCallback = env.globMock.secondCall.args[2];
   });
 
   it('searches for webpack configs', function() {
-    expect(env.globMock).to.have.been.calledOnce;
+    expect(env.globMock).to.have.been.calledTwice;
     expect(env.globMock).to.have.been.calledWith('**/webpack.config.js');
   });
 
   it('searches within the dependency examples', function() {
-    expect(env.globMock).to.have.been.calledOnce;
     expect(env.globMock.firstCall.args[1].cwd).to.equal('node_modules/raw-loader/examples');
+    expect(env.globMock.secondCall.args[1].cwd).to.equal('node_modules/raw-loader/example');
   });
 
   describe('when error finding examples', function() {
-    beforeEach(function() {
-      env.globCallback(new Error('test'));
+    beforeEach(function(done) {
+      env.examplesGlobCallback(new Error('test'));
+      setTimeout(done, 10)
     });
 
     it('calls the callback with error', function() {
       expect(env.callbackMock).to.have.been.calledOnce;
-      expect(env.callbackMock).to.have.been.calledWith(new Error());
+      expect(env.callbackMock.firstCall.args[0].toString()).to.equal('Error: test');
     });
   });
 
   describe('when one example found', function() {
-    beforeEach(function() {
-      env.globCallback(null, ['webpack.config.js']);
+    beforeEach(function(done) {
+      env.examplesGlobCallback(null, ['webpack.config.js']);
+      env.exampleGlobCallback(null, []);
+      setTimeout(done, 10)
     });
 
     it('calls the callback with array of one config', function() {
@@ -59,13 +63,14 @@ describe('getDependencyExamples', function() {
   });
 
   describe('when multiple examples found', function() {
-    beforeEach(function() {
+    beforeEach(function(done) {
       const examples = [
         'example-1/webpack.config.js',
-        'example-2/webpack.config.js',
-        'example-3/webpack.config.js'
+        'example-2/webpack.config.js'
       ];
-      env.globCallback(null, examples);
+      env.examplesGlobCallback(null, examples);
+      env.exampleGlobCallback(null, ['webpack.config.js']);
+      setTimeout(done, 10)
     });
 
     it('calls the callback with array of one config', function() {
@@ -80,16 +85,18 @@ describe('getDependencyExamples', function() {
           config: 'node_modules/raw-loader/examples/example-2/webpack.config.js'
         },
         {
-          name: 'example-3',
-          config: 'node_modules/raw-loader/examples/example-3/webpack.config.js'
+          name: undefined,
+          config: 'node_modules/raw-loader/example/webpack.config.js'
         }
       ]);
     });
   });
 
   describe('when no examples found', function() {
-    beforeEach(function() {
-      env.globCallback(null, []);
+    beforeEach(function(done) {
+      env.examplesGlobCallback(null, []);
+      env.exampleGlobCallback(null, []);
+      setTimeout(done, 10)
     });
 
     it('calls the callback with empty array', function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import Promise from "bluebird";
+import Promise from 'bluebird';
 import chalk from 'chalk';
 import getLogger from './logger';
 import generateInstallObjectFor from './generate-install-object';

--- a/lib/run-dependency-with-webpack/index.js
+++ b/lib/run-dependency-with-webpack/index.js
@@ -5,13 +5,14 @@ import url from 'url';
 import _ from 'underscore';
 
 const webpack = './node_modules/webpack/bin/webpack.js';
-const replacementMapping = {
-  'node ': 'node --no-warnings ',
-  '<insert local ip>': '127.0.0.1'
-};
+const replacementMapping = [
+  { replaceable: 'node ', replacement: 'node --no-warnings ' },
+  { replaceable: '<insert local ip>', replacement: '127.0.0.1' },
+  { replaceable: /^webpack-dev-server$/, replacement: 'node ../bin/webpack-dev-server.js' }
+];
 
 const applyReplacements = function(exampleCompilerCommand) {
-  return _.reduce(replacementMapping, function(command, replacement, replaceable) {
+  return _.reduce(replacementMapping, function(command, { replacement, replaceable }) {
     return command.replace(replaceable, replacement);
   }, exampleCompilerCommand)
 };
@@ -51,8 +52,7 @@ const getExampleCompilerCommand = function(exampleDirectory) {
   if (!_.isArray(command)) return command;
   const exampleCompilerCommand = command[1]
     .split('\n')
-    .slice(1, -1)
-    .join('\n');
+    .slice(1, -1)[0];
   return applyReplacements(exampleCompilerCommand);
 };
 
@@ -74,9 +74,7 @@ export default function(configPath, completeExample) {
     exampleRun.kill();
   };
 
-  exampleRunTimeout = setTimeout(function() {
-    killExample();
-  }, 10000);
+  exampleRunTimeout = setTimeout(killExample, 10000);
 
   exampleRun.stdout.on('data', (data) => {
     const stdout = data.toString();


### PR DESCRIPTION
Allow different example directories to be supported. This change allows the dev server v1 example to be supported, and should finally have a passing green build of the squawk run on Travis.