### PR TITLE
Add support for package manager selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ node index.js --webpack=<webpack_reference> --dependency=<dependency_reference>
 
  - `--webpack` can be a version or path to remote repository
  - `--dependency` can be a dependency name (with or without version) or path to remote repository
+ - `--package-manager` (optional) can be set to `yarn` to use yarn for installation of modules. If not set (or set to anything else) it will default to npm
 
 #### Example
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,12 @@ import runner from './runner';
 
 const loglevel = argv.loglevel || 'info';
 const logger = getLogger(loglevel);
-const options = { loglevel: loglevel };
+const options = {
+  loglevel: loglevel,
+  packageManager: argv.packageManager,
+};
 
-runner(argv.webpack, argv.dependency, options, argv.packageManager)
+runner(argv.webpack, argv.dependency, options)
   .then(
     () => logger.success('All examples passed'),
     (error) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const loglevel = argv.loglevel || 'info';
 const logger = getLogger(loglevel);
 const options = { loglevel: loglevel };
 
-runner(argv.webpack, argv.dependency, options)
+runner(argv.webpack, argv.dependency, options, argv.packageManager)
   .then(
     () => logger.success('All examples passed'),
     (error) => {

--- a/lib/install-webpack-and-dependency/index.js
+++ b/lib/install-webpack-and-dependency/index.js
@@ -3,21 +3,45 @@ import childProcess from 'child_process';
 import { ROOT_PATH } from '../consts';
 
 /**
+ * Get the commands that should be run
+ *
+ * @export
+ * @param {InstallObject} webpackSetup - Webpack install object
+ * @param {InstallObject} dependencySetup - Dependency install object
+ * @param {string} packageManager - Package manager that should be used (npm or yarn)
+ * @returns {Object} Install and install dependency commands
+ */
+const getCommands = function(webpackSetup, dependencySetup, packageManager) {
+  if (packageManager === 'yarn') {
+    return {
+      install: `yarn add ${webpackSetup} ${dependencySetup}`,
+      installDeps: 'yarn'
+    };
+  }
+
+  return {
+    install: `npm install ${webpackSetup} ${dependencySetup}`,
+    installDeps: 'npm install'
+  };
+}
+
+/**
  * Installs the Webpack and dependency modules
  *
  * @export
  * @param {InstallObject} webpackSetup - Webpack install object
  * @param {InstallObject} dependencySetup - Dependency install object
+ * @param {string} packageManager - Package manager that should be used (npm or yarn)
  * @returns {Promise} A promise indicating the installation success
  */
-export default function(webpackSetup, dependencySetup) {
-  const installCommand = `npm install ${webpackSetup} ${dependencySetup} --loglevel error`;
+export default function(webpackSetup, dependencySetup, packageManager) {
+  const commands = getCommands(webpackSetup, dependencySetup, packageManager);
 
   return new Promise((resolve, reject) => {
 
     // IMPORTANT: ROOT_PATH needs to contain a package.json file
     // If it doesn't exist, npm will search for the closest package.json and install into this folder
-    childProcess.exec(installCommand, { cwd: ROOT_PATH }, function(err, stdout, stderr) {
+    childProcess.exec(commands.install, { cwd: ROOT_PATH }, function(err, stdout, stderr) {
       if (err) {
         return reject(['Error calling install command', err]);
       }
@@ -31,7 +55,7 @@ export default function(webpackSetup, dependencySetup) {
         return reject(['Expected versions not in dependency tree', stdout]);
       }
 
-      return childProcess.exec('npm install', { cwd: dependencySetup.installLocation }, (err) => {
+      return childProcess.exec(commands.installDeps, { cwd: dependencySetup.installLocation }, (err) => {
         if (err) {
           return reject(['Error calling install command for dependency build', err]);
         }

--- a/lib/install-webpack-and-dependency/test/index.spec.js
+++ b/lib/install-webpack-and-dependency/test/index.spec.js
@@ -27,7 +27,16 @@ describe('installWebpackAndDependency', function() {
 
   it('calls npm install with correct values', function() {
     expect(env.childProcessStub.exec).to.have.been.calledOnce;
-    expect(env.childProcessStub.exec).to.have.been.calledWith('npm install webpack@2.3.4 raw-loader@1.2.3 --loglevel error', { cwd: ROOT_PATH });
+    expect(env.childProcessStub.exec).to.have.been.calledWith('npm install webpack@2.3.4 raw-loader@1.2.3', { cwd: ROOT_PATH });
+  });
+
+  it('calls yarn add with correct values', function() {
+    // Note: First call is with npm
+    env.installPromise = env.installWebpackAndDependency(env.webpack, env.dependency, 'yarn');
+    env.webpackInstallCallback = env.childProcessStub.exec.secondCall.args[2];
+    expect(env.childProcessStub.exec).to.have.been.calledTwice;
+
+    expect(env.childProcessStub.exec.secondCall).to.have.been.calledWith('yarn add webpack@2.3.4 raw-loader@1.2.3', { cwd: ROOT_PATH });
   });
 
   describe('when error installing', function() {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -13,11 +13,10 @@ import runDependencyWithWebpack from './run-dependency-with-webpack';
  * @export
  * @param {String} webpackVersion - Entered Webpack version info
  * @param {String} dependencyVersion - Entered dependency info
- * @param {Object} options - Logger options
- * @param {string} packageManager - Package manager that should be used (npm or yarn)
+ * @param {Object} options - CLI options
  * @returns {Promise} Promise indicating the process success
  */
-export default async function(webpackVersion, dependencyVersion, options, packageManager) {
+export default async function(webpackVersion, dependencyVersion, options) {
   const logger = getLogger(options.loglevel);
 
   const webpackSetup = generateInstallObjectFor.webpack(webpackVersion);
@@ -36,7 +35,7 @@ export default async function(webpackVersion, dependencyVersion, options, packag
 
   logger.info(`Installing ${chalk.bold(webpackSetup)} and ${chalk.bold(dependencySetup)} ...`);
 
-  await installWebpackAndDependency(webpackSetup, dependencySetup, packageManager);
+  await installWebpackAndDependency(webpackSetup, dependencySetup, options.packageManager);
 
   logger.info(`Retrieving ${chalk.bold(dependencySetup.name)} examples ...`);
   const dependencyExamples = await getDependencyExamples(webpackSetup, dependencySetup);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -14,6 +14,7 @@ import runDependencyWithWebpack from './run-dependency-with-webpack';
  * @param {String} webpackVersion - Entered Webpack version info
  * @param {String} dependencyVersion - Entered dependency info
  * @param {Object} options - Logger options
+ * @param {string} packageManager - Package manager that should be used (npm or yarn)
  * @returns {Promise} Promise indicating the process success
  */
 export default async function(webpackVersion, dependencyVersion, options, packageManager) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -16,7 +16,7 @@ import runDependencyWithWebpack from './run-dependency-with-webpack';
  * @param {Object} options - Logger options
  * @returns {Promise} Promise indicating the process success
  */
-export default async function(webpackVersion, dependencyVersion, options) {
+export default async function(webpackVersion, dependencyVersion, options, packageManager) {
   const logger = getLogger(options.loglevel);
 
   const webpackSetup = generateInstallObjectFor.webpack(webpackVersion);
@@ -35,7 +35,7 @@ export default async function(webpackVersion, dependencyVersion, options) {
 
   logger.info(`Installing ${chalk.bold(webpackSetup)} and ${chalk.bold(dependencySetup)} ...`);
 
-  await installWebpackAndDependency(webpackSetup, dependencySetup);
+  await installWebpackAndDependency(webpackSetup, dependencySetup, packageManager);
 
   logger.info(`Retrieving ${chalk.bold(dependencySetup.name)} examples ...`);
   const dependencyExamples = await getDependencyExamples(webpackSetup, dependencySetup);

--- a/test_modules/package.json
+++ b/test_modules/package.json
@@ -1,4 +1,5 @@
 {
   "name": "webpack-canary-test",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "license": "ISC"
 }


### PR DESCRIPTION
Adds a `--package-manager` flag that can currently be set to `yarn`. Might add some other options in future if needed. Related to #21.

Currently has no effect on squawk, but will be used once #26 is done.