### PR TITLE
chore(license): update package.json license field to be Apache 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "squawk": "node ./squawk.js"
   },
   "author": "Alistair Brown <npm@alistairjcbrown.com> (http://alistairjcbrown.com/)",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-preset-env": "^1.6.0",


### PR DESCRIPTION
This shouldn't block our current release since we already have a LICENSE file in our repo root, however this will make scanners happier down the road :-D 